### PR TITLE
Add 3.11 versions

### DIFF
--- a/wiki/products/v3/tfgrid_3.11.toml
+++ b/wiki/products/v3/tfgrid_3.11.toml
@@ -33,7 +33,7 @@ version = "0.10.1"
 repo = "https://github.com/threefoldtech/tfgrid-sdk-go"
 
 [tfgrid-sdk-ts]
-version = "2.1.0"
+version = "2.1.0-rc3"
 repo = "https://github.com/threefoldtech/tfgrid-sdk-ts"
 [[tfgrid-sdk-ts.services.dashboard]]
 path="packages/dashboard"

--- a/wiki/products/v3/tfgrid_3.11.toml
+++ b/wiki/products/v3/tfgrid_3.11.toml
@@ -1,0 +1,49 @@
+[tfchain]
+version = "2.5.0-rc7"
+repo = "https://github.com/threefoldtech/tfchain"
+[[tfchain.services.node]]
+version = ">=2.2.1"
+path="substrate-node"
+
+[tfchain_activation_service]
+version="1.0.1"
+
+[tfchain_client_js]
+version = "2.5.0-rc7"
+repo = "https://github.com/threefoldtech/tfchain"
+
+[tfchain_graphl]
+version = "2.9.2"
+repo = "https://github.com/threefoldtech/tfchain_graphql"
+
+[zos]
+version = "3.8.0"
+repo = "https://github.com/threefoldtech/zos"
+
+[tfgrid-sdk-go]
+version = "0.10.1"
+repo = "https://github.com/threefoldtech/tfgrid-sdk-go"
+
+[terraform]
+version = "2.0.0"
+repo = "https://github.com/threefoldtech/tfgrid-sdk-go"
+
+[gridproxy]
+version = "0.10.1"
+repo = "https://github.com/threefoldtech/tfgrid-sdk-go"
+
+[tfgrid-sdk-ts]
+version = "2.1.0"
+repo = "https://github.com/threefoldtech/tfgrid-sdk-ts"
+[[tfgrid-sdk-ts.services.dashboard]]
+path="packages/dashboard"
+[[tfgrid-sdk-ts.services.weblets]]
+path="packages/weblets"
+[[tfgrid-sdk-ts.services.playground]]
+path="packages/playground"
+[[tfgrid-sdk-ts.services.stats]]
+path="packages/stats"
+
+[rmb]
+version="1.0.5"
+repo="https://github.com/threefoldtech/rmb-rs"


### PR DESCRIPTION
Adds the initial versions of 3.11 that's going to be deployed on qanet 

zos: 3.8
tfchain: 2.5.0-rc7
sdk-go: 0.10.1
sdk-ts: 2.1.0-rc3